### PR TITLE
fix: use L1_CHAIN_ID instead of connected chain

### DIFF
--- a/apps/converter/src/components/account/Tabs.tsx
+++ b/apps/converter/src/components/account/Tabs.tsx
@@ -77,7 +77,7 @@ export default function Tabs() {
             // redirect to bridge app if the user chooses the deposit / withdraw app
             if (val !== 2) {
               window.open(
-                `${MANTLE_BRIDGE_URL[chainId]}/account/${
+                `${MANTLE_BRIDGE_URL[L1_CHAIN_ID]}/account/${
                   val === 0 ? "deposit" : "withdraw"
                 }`,
                 "_self"

--- a/apps/converter/src/components/converter/dialogue/Converted.tsx
+++ b/apps/converter/src/components/converter/dialogue/Converted.tsx
@@ -5,6 +5,7 @@ import {
   L1_MANTLE_TOKEN,
   MANTLE_BRIDGE_URL,
   DELEGATION_URL,
+  L1_CHAIN_ID,
 } from "@config/constants";
 
 import { Button, Typography } from "@mantle/ui";
@@ -167,7 +168,7 @@ export default function Deposited({
           image="/converted/link-2.png"
           title="Bridge"
           description="Move your tokens to Mantle Network"
-          href={MANTLE_BRIDGE_URL[chainId] || "#"}
+          href={MANTLE_BRIDGE_URL[L1_CHAIN_ID] || "#"}
         />
         <WhatNextLink
           image="/converted/link-3.png"


### PR DESCRIPTION
I should use L1_CHAIN_ID to find the bridge URL as it represents the network of the app should connect to 
The current implementation of using `chainId` might cause the url not found if the user connects any network other than Ethereum mainnet and Goerli