### PR TITLE
fix(faucet): correct Mantle Hoodi chain id to 50002

### DIFF
--- a/apps/faucet/src/config/constants.ts
+++ b/apps/faucet/src/config/constants.ts
@@ -47,7 +47,7 @@ export const FAUCET_API_URL =
 
 // Chain IDs
 export const MantleSepoliaChainId = 5003;
-export const MantleHoodiChainId = 5001;
+export const MantleHoodiChainId = 50002;
 
 // All supported faucet chain IDs (used for the chain selector)
 export const SUPPORTED_CHAIN_IDS = [


### PR DESCRIPTION
## Summary

- Fix the `MantleHoodiChainId` constant in `apps/faucet/src/config/constants.ts` from `5001` to `50002` so the faucet wagmi config, chain selector and faucet RPC calls all target the correct Mantle Hoodi network.

## Test plan

- [ ] `pnpm -F mantle-faucet build` succeeds
- [ ] Open faucet, select **Mantle Hoodi** in the chain selector
- [ ] Verify the reserve balance loads from the Hoodi RPC
- [ ] Connect wallet, switch wallet to Hoodi, claim a small amount — succeeds against chain id 50002

🤖 Generated with [Claude Code](https://claude.com/claude-code)