### PR TITLE
fix(converter): fail over across RPC pool for balance reads

### DIFF
--- a/apps/converter/src/config/constants.ts
+++ b/apps/converter/src/config/constants.ts
@@ -161,7 +161,10 @@ export const CHAINS: Record<
       `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ETH_MAINNET_KEY}`,
       // infura backed redirect gateway
       // `${ABSOLUTE_PATH}/rpc`,
-      "https://eth.llamarpc.com",
+      // "https://eth.llamarpc.com",
+      "https://ethereum-rpc.publicnode.com",
+      "https://eth.drpc.org",
+      "https://rpc.ankr.com/eth/acfad6cee74f202a2e0446f4217f46b1d75990ffa142fa00ed86aa3b7f7c4009",
     ],
     blockExplorerUrls: ["https://etherscan.io/"],
   },
@@ -213,10 +216,12 @@ export const CHAINS_FORMATTED: Record<number, Chain & { network: string }> = {
     network: CHAINS[1].chainName,
     rpcUrls: {
       default: {
+        // alchemy — kept for the wagmi/rainbowkit write transport
         http: [CHAINS[1].rpcUrls[0]],
       },
       public: {
-        http: [CHAINS[1].rpcUrls[1]],
+        // public pool (everything after alchemy) — primary for read hooks
+        http: CHAINS[1].rpcUrls.slice(1),
       },
     },
     id: 1,

--- a/apps/converter/src/hooks/web3/converter/read/useAllowanceCheck.ts
+++ b/apps/converter/src/hooks/web3/converter/read/useAllowanceCheck.ts
@@ -1,14 +1,14 @@
 import {
-  CHAINS_FORMATTED,
   L1_BITDAO_TOKEN,
   L1_BITDAO_TOKEN_ADDRESS,
   L1_CONVERTER_V2_CONTRACT_ADDRESS,
   TOKEN_ABI,
 } from "@config/constants";
-import { BigNumberish, Contract, providers } from "ethers";
+import { BigNumberish, Contract } from "ethers";
 
 import { formatUnits, parseUnits } from "ethers/lib/utils.js";
 import { useQuery } from "wagmi/query";
+import { getFallbackProvider } from "@utils/getFallbackProvider";
 
 function useAllowanceCheck(
   chainId: number,
@@ -24,9 +24,7 @@ function useAllowanceCheck(
       },
     ],
     queryFn: () => {
-      const provider = new providers.JsonRpcProvider(
-        CHAINS_FORMATTED[chainId].rpcUrls.public.http[0]
-      );
+      const provider = getFallbackProvider(chainId);
       // only run the multicall if we're connected to the correct network
       if (client?.address && client?.address !== "0x") {
         if (client.address) {

--- a/apps/converter/src/hooks/web3/converter/read/useGasEstimate.ts
+++ b/apps/converter/src/hooks/web3/converter/read/useGasEstimate.ts
@@ -1,15 +1,15 @@
 import {
-  CHAINS_FORMATTED,
   L1_BITDAO_TOKEN,
   L1_BITDAO_TOKEN_ADDRESS,
   L1_CHAIN_ID,
   L1_CONVERTER_CONTRACT_ABI,
   L1_CONVERTER_CONTRACT_ADDRESS,
 } from "@config/constants";
-import { BigNumber, Contract, constants, providers } from "ethers";
+import { BigNumber, Contract, constants } from "ethers";
 
 import { formatUnits, parseUnits } from "ethers/lib/utils.js";
 import { useQuery } from "wagmi/query";
+import { getFallbackProvider } from "@utils/getFallbackProvider";
 
 function useGasEstimate(
   chainId: number,
@@ -34,9 +34,7 @@ function useGasEstimate(
       },
     ],
     queryFn: async () => {
-      const provider = new providers.JsonRpcProvider(
-        CHAINS_FORMATTED[L1_CHAIN_ID].rpcUrls.public.http[0]
-      );
+      const provider = getFallbackProvider(L1_CHAIN_ID);
       // only run the call if we're connected to the correct network and user has appropriate balance
       if (
         client?.address &&

--- a/apps/converter/src/hooks/web3/read/useAccountBalance.ts
+++ b/apps/converter/src/hooks/web3/read/useAccountBalance.ts
@@ -1,6 +1,7 @@
-import { CHAINS_FORMATTED, L1_CHAIN_ID } from "@config/constants";
-import { BigNumber, Contract, providers } from "ethers";
+import { L1_CHAIN_ID } from "@config/constants";
+import { BigNumber, Contract } from "ethers";
 import { useQuery } from "wagmi/query";
+import { getFallbackProvider } from "@utils/getFallbackProvider";
 
 function useAccountBalance(address: `0x${string}`, token: string) {
   // perform a multicall on the given network to get all token balances for user
@@ -17,9 +18,7 @@ function useAccountBalance(address: `0x${string}`, token: string) {
       },
     ],
     queryFn: async () => {
-      const provider = new providers.JsonRpcProvider(
-        CHAINS_FORMATTED[L1_CHAIN_ID].rpcUrls.public.http[0]
-      );
+      const provider = getFallbackProvider(L1_CHAIN_ID);
       const abi = [
         {
           constant: true,

--- a/apps/converter/src/hooks/web3/read/useAccountBalances.ts
+++ b/apps/converter/src/hooks/web3/read/useAccountBalances.ts
@@ -1,17 +1,17 @@
 import {
-  CHAINS_FORMATTED,
   L1_CHAIN_ID,
   L2_CHAIN_ID,
   MULTICALL_CONTRACTS,
   TOKEN_ABI,
   Token,
 } from "@config/constants";
-import { Contract, providers } from "ethers";
+import { Contract } from "ethers";
 
 import {
   callMulticallContract,
   getMulticallContract,
 } from "@utils/multicallContract";
+import { getFallbackProvider } from "@utils/getFallbackProvider";
 import { formatUnits } from "ethers/lib/utils.js";
 import { useQuery } from "wagmi/query";
 
@@ -36,11 +36,9 @@ function useAccountBalances(
       },
     ],
     queryFn: async () => {
-      // connect to L1 on public gateway but use default rpc for L2
-      const provider = new providers.JsonRpcProvider(
-        CHAINS_FORMATTED[
-          chainId === L1_CHAIN_ID ? L1_CHAIN_ID : L2_CHAIN_ID
-        ].rpcUrls.public.http[0]
+      // fail over across the chain's RPC pool (L1: public nodes → alchemy; L2: default)
+      const provider = getFallbackProvider(
+        chainId === L1_CHAIN_ID ? L1_CHAIN_ID : L2_CHAIN_ID
       );
       // get the current multicall contract
       const multicall = await getMulticallContract(

--- a/apps/converter/src/utils/getFallbackProvider.ts
+++ b/apps/converter/src/utils/getFallbackProvider.ts
@@ -1,0 +1,59 @@
+import { CHAINS_FORMATTED } from "@config/constants";
+import { providers } from "ethers";
+
+// How long (ms) to wait on a stalled RPC before racing the next one in the pool.
+const STALL_TIMEOUT = 1500;
+
+// Reuse one provider per chain instead of rebuilding it on every query refetch.
+const providerCache = new Map<number, providers.BaseProvider>();
+
+/**
+ * Build an ethers provider that fails over across every RPC configured for the
+ * chain. Public endpoints (rpcUrls.public) are tried first; the keyed default
+ * endpoint (rpcUrls.default, e.g. Alchemy) is the last resort, so its quota is
+ * only spent when every public node is stalling or down.
+ *
+ * Each child is constructed with an explicit network, so there is no eth_chainId
+ * round-trip on construction and `provider.network` is available synchronously
+ * (useGasEstimate reads it).
+ */
+export function getFallbackProvider(chainId: number): providers.BaseProvider {
+  const cached = providerCache.get(chainId);
+  if (cached) return cached;
+
+  const chain = CHAINS_FORMATTED[chainId];
+  if (!chain) {
+    throw new Error(
+      `getFallbackProvider: no chain config for chainId ${chainId}`
+    );
+  }
+
+  // public pool first, keyed default last — falsy entries dropped, then de-duped
+  const urls = [
+    ...chain.rpcUrls.public.http,
+    ...chain.rpcUrls.default.http,
+  ].filter(Boolean);
+  const uniqueUrls = Array.from(new Set(urls));
+
+  if (uniqueUrls.length === 0) {
+    throw new Error(`getFallbackProvider: no RPC urls for chainId ${chainId}`);
+  }
+
+  const network = { chainId, name: chain.network };
+
+  const provider =
+    uniqueUrls.length === 1
+      ? new providers.StaticJsonRpcProvider(uniqueUrls[0], network)
+      : new providers.FallbackProvider(
+          uniqueUrls.map((url, index) => ({
+            provider: new providers.StaticJsonRpcProvider(url, network),
+            priority: index + 1, // lower = preferred; public pool 1..n, default last
+            stallTimeout: STALL_TIMEOUT,
+            weight: 1,
+          })),
+          1 // quorum: a single successful response is enough
+        );
+
+  providerCache.set(chainId, provider);
+  return provider;
+}


### PR DESCRIPTION
The read hooks each built a JsonRpcProvider from a single public RPC with no failover, so a stalled or down endpoint hung balance, allowance and gas queries — the source of the sync timeout.

- add getFallbackProvider: an ethers FallbackProvider over the chain's RPC pool, public nodes first with the keyed default (Alchemy) as last resort; quorum 1, 1500ms stall timeout, cached per chain
- point useAccountBalances, useAccountBalance, useGasEstimate and useAllowanceCheck at it
- CHAINS_FORMATTED[1].public now spans the whole public pool (slice(1)) instead of a single index